### PR TITLE
Fixed banner color CSS rules and added an option for enabling them

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Set the `ozp-color-banners` attribute to true to enable colored banner backgroun
 ```
 
 ## Bower
-You can use the plugin or directive with Bower. Install with `bower install ozone-development/ozp-classification`.
+You can use the plugin or directive with Bower. Install with `bower install ozoneplatform/ozp-classification`.
 
 ## CSS
 The CSS assumes the banners will be attached to the body tag. If you want the bottom banner to appear at the bottom of the rendering window, you will probably need to add something like this to your css:

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ The core of these utilities is the jQuery plugin, contained in `jquery.classific
 
 ```javascript
 $(function(){
-    $(document).classification({ 
-        level: "U" 
+    $(document).classification({
+        level: "U"
     });
 });
 ```
 
-### Settings 
+### Settings
 The plugin settings and defaults are:
 ```javascript
 var defaults = settings = {
@@ -26,7 +26,9 @@ var defaults = settings = {
     // If dynamic above is true, do we want two bars to represent the classification
     dynamicBanner: false,
     // What color should "Top Secret" be? Default is yellow, orange if this is true
-    tsOrange: false
+    tsOrange: false,
+    // Banner backgrounds are not colored by default; set to true to color by classification level
+    colorBanners: false
 };
 ```
 
@@ -41,6 +43,12 @@ You are then able to attach a classification to the body tag:
 
 ```html
 <body ozp-classification="U-FOUO">...</body>
+```
+
+Set the `ozp-color-banners` attribute to true to enable colored banner backgrounds:
+
+```html
+<body ozp-classification="U-FOUO" ozp-color-banners="true">...</body>
 ```
 
 ## Bower

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "ozp-classification.js"
   ],
   "version": "0.0.1",
-  "homepage": "https://github.com/ozone-development/ozp-classification",
+  "homepage": "https://github.com/ozoneplatform/ozp-classification",
   "authors": [
     "Ozone Developers"
   ],

--- a/classification.css
+++ b/classification.css
@@ -10,29 +10,28 @@
     color: #f9f9f9;
     background-color: #4f5457;
 }
-/*
-.U-FOUO {
+
+.U-FOUO.classBanner {
     background-color: #009900;
 }
 
-.Conf {
+.Conf.classBanner {
     background-color: #0000FF;
 }
 
-.Secret {
+.Secret.classBanner {
     background-color: #FF0000;
 }
 
-.TopSecret-Orange {
+.TopSecret-Orange.classBanner {
     background-color: #FF6600;
 }
 
-.TopSecret-Yellow {
+.TopSecret-Yellow.classBanner {
     background-color: #FFFF00;
     color: black;
 }
 
-.Dynamic {
+.Dynamic.classBanner {
     background-color: #000000;
 }
-*/

--- a/jquery.classification.js
+++ b/jquery.classification.js
@@ -3,10 +3,10 @@
 
 /**
  * jQuery.classification.js
- * 
+ *
  * This is a jQuery plugin that creates classification banners on an HTML document.
  *
- * This plugin is used by a call to the jQuery function and can be chained. It takes string 
+ * This plugin is used by a call to the jQuery function and can be chained. It takes string
  * parameters that are methods, or it can take a configuration object with your desired settings.
  * The plugin works by injecting divs onto the body element.
  * Ex: $(document).classification({ dynamic: true, level: 'S-2P' })
@@ -129,13 +129,13 @@
     /**
      * @cfg $.fn.classification.defaults {Object}
      * Classification plugin default settings.
-     * 
+     *
      * @cfg $.fn.classification.defaults.dynamic {Boolean} [dynamic = false]
      * True if you want to display "Dynamic page" in the banner.
-     * 
+     *
      * @cfg $.fn.classification.level {String} [level = 'U-FOUO']
      * A string representing the classification level, any compartments, and dissemination.
-     * 
+     *
      * @cfg $.fn.classification.defaults.dynamicBanner {Boolean} [dynamicBanner = false]
      * True if a separate banner is needed for dynamic content.
      *
@@ -146,7 +146,8 @@
         dynamic: false,
         level: 'U-FOUO',
         dynamicBanner: false,
-        tsOrange: false
+        tsOrange: false,
+        colorBanners: false
     };
 
     /**
@@ -162,8 +163,9 @@
         var txt = settings.level;
         var level = txt.charAt(0);
         var bannerText = text[txt];
+        var bannerClass = 'classBanner';
 
-        // If no dynamic banner is desired and dynamic text is desired ... 
+        // If no dynamic banner is desired and dynamic text is desired ...
         if (!settings.dynamicBanner && settings.dynamic) {
             // then we concat the dynamic text to the level text - to make one banner.
             bannerText = dText + ' ' + text[txt];
@@ -175,22 +177,30 @@
             if (settings.tsOrange) {
                 tsColor = 'Orange'
             }
-            head = $(divText).addClass('classBanner TopSecret-' + tsColor).html(bannerText);
-            foot = $(divText).addClass('classBanner TopSecret-' + tsColor).html(bannerText);
+
+            if (settings.colorBanners) {
+                bannerClass += ' TopSecret-' + tsColor;
+            }
             break;
         case 'S':
-            head = $(divText).addClass('classBanner Secret').html(bannerText);
-            foot = $(divText).addClass('classBanner Secret').html(bannerText);
+            if (settings.colorBanners) {
+                bannerClass += ' Secret';
+            }
             break;
         case 'C':
-            head = $(divText).addClass('classBanner Conf').html(bannerText);
-            foot = $(divText).addClass('classBanner Conf').html(bannerText);
+            if (settings.colorBanners) {
+                bannerClass += ' Conf';
+            }
             break;
         case 'U':
-            head = $(divText).addClass('classBanner U-FOUO').html(bannerText);
-            foot = $(divText).addClass('classBanner U-FOUO').html(bannerText);
+            if (settings.colorBanners) {
+                bannerClass += ' U-FOUO';
+            }
             break;
         }
+
+        head = $(divText).addClass(bannerClass).html(bannerText);
+        foot = $(divText).addClass(bannerClass).html(bannerText);
 
         // Add header
         var $body = $('body');

--- a/ozp-classification.js
+++ b/ozp-classification.js
@@ -6,7 +6,15 @@ angular.module('ozpClassification', [])
         return {
             restrict: 'A',
             link: function(scope, element, attrs) {
-                element.classification({ level: attrs.ozpClassification });
+                var options = {
+                    level: attrs.ozpClassification
+                };
+
+                if (!angular.isUndefined(attrs.ozpColorBanners)) {
+                    options.colorBanners = attrs.ozpColorBanners;
+                }
+
+                element.classification(options);
             }
         };
     });

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/ozone-development/ozp-classification"
+    "url": "https://github.com/ozoneplatform/ozp-classification"
   },
   "author": "emosher",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/ozone-development/ozp-classification/issues"
+    "url": "https://github.com/ozoneplatform/ozp-classification/issues"
   },
-  "homepage": "https://github.com/ozone-development/ozp-classification"
+  "homepage": "https://github.com/ozoneplatform/ozp-classification"
 }


### PR DESCRIPTION
This request fixes #9 by uncommenting the banner color CSS rules and adding an option to enable them; banners are not colored by default.

Screenshots of changes tested:

Webtop, pre-changes:

![webtop_pre_change](https://cloud.githubusercontent.com/assets/3136972/20398095/f5869acc-acb9-11e6-88ef-fe9b93db3ab4.PNG)

Webtop, post-changes with colors **enabled**:

![webtop_post_change_color_enabled](https://cloud.githubusercontent.com/assets/3136972/20398117/0d15d77a-acba-11e6-88da-85eada3c778a.PNG)

Webtop, post-changes with colors **disabled**:

![webtop_post_change_color_disabled](https://cloud.githubusercontent.com/assets/3136972/20398122/13f2ade8-acba-11e6-933d-82234153c636.PNG)